### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 668: UNCONTROLLED DATA USED IN PATH EXPRESSION

### DIFF
--- a/sdk/src/as/as.c
+++ b/sdk/src/as/as.c
@@ -280,6 +280,13 @@
                       "invalid dependency file path `%s'", depend_file);
              return;
          }
+         // Validate the dependency file path
+         if (has_path_traversal(depend_file))
+         {
+             as_error(ERR_NONFATAL | ERR_NOFILE | ERR_USAGE,
+                      "unsafe dependency file path `%s'", depend_file);
+             return;
+         }
          int fd = open(depend_file, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
          if (fd < 0)
          {


### PR DESCRIPTION
_Potential fix for [https://github.com/pmfs1/krlean/security/code-scanning/668](https://github.com/pmfs1/krlean/security/code-scanning/668)._

_To fix the problem, we need to validate the `depend_file` variable before it is used in the `open` function. We can use the existing `has_path_traversal` function to check for directory traversal patterns and ensure that the path is safe. If the path is found to be unsafe, we should handle the error appropriately._
- _Add a validation check for `depend_file` using the `has_path_traversal` function before the `open` function call._
- _If the validation fails, log an error message and return early to prevent the unsafe path from being used._
